### PR TITLE
mkdocs-material Docker image based on binary

### DIFF
--- a/Dockerfile_binary-linux-amd64
+++ b/Dockerfile_binary-linux-amd64
@@ -1,0 +1,31 @@
+### 1. Docker build stage: Create MkDocs binary
+FROM squidfunk/mkdocs-material:8.1.3 as source
+
+# Install PyInstaller and required tools
+RUN apk add binutils upx
+RUN pip install --upgrade pip # As time of writing, installed pip v21.0.1 does not work, upgraded v21.3.1 does
+RUN pip install pyinstaller
+
+# Create MkDocs binary inluding material theme
+WORKDIR /tmp
+RUN pyinstaller --recursive-copy-metadata mkdocs --collect-all mkdocs \
+  --copy-metadata mkdocs-material --collect-all material --name mkdocs-material \
+  $(pip show mkdocs | grep Location | sed -e 's/^Location: //')/mkdocs/__main__.py
+
+
+### Final Docker image: Serving MkDocs binary
+FROM alpine
+
+COPY --from=source /tmp/dist/mkdocs-material /opt/mkdocs-material
+RUN ln -s /opt/mkdocs-material/mkdocs-material /usr/local/bin/mkdocs
+
+# Required for "Publishing your site" to GitHub Pages,
+# see https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-mkdocs
+RUN apk add --no-cache git git-fast-import openssh
+
+WORKDIR /docs
+
+# Start development server by default
+EXPOSE 8000
+ENTRYPOINT ["mkdocs"]
+CMD ["serve", "--dev-addr=0.0.0.0:8000"]


### PR DESCRIPTION
Original mkdocs-material Docker image is using mkdocs the "classic" way by executing Python.
This docker image encapsulates mkdocs as a binary.

Follow up of https://github.com/squidfunk/mkdocs-material/pull/3375

This is smaller

    ms/mkdocs-material3         latest              ab1643b0bb7a   About a minute ago   65.3MB
    squidfunk/mkdocs-material   latest              bd43b9c59ff4   2 days ago           98.8MB

Faster startup, ~500ms on my machine. Valid for build, serve etc.

    $ time docker run squidfunk/mkdocs-material -V
    real    0m1,362s
    $ time docker run ms/mkdocs-material3 -V
    real    0m0,840s

Other characteristics (CPU/RAM consumption) seem to be comparable to the original.

Limitation "no additional mkdocs plugin possible" still exists. Though I think this can be added using `docker --build-arg`, I think this is only worth investigating if a user raises an issue.